### PR TITLE
Made LogLevel.ParseLogLevel static, preventing crash when passing --l…

### DIFF
--- a/DSLink/Util/Logger/LogLevel.cs
+++ b/DSLink/Util/Logger/LogLevel.cs
@@ -62,7 +62,7 @@ namespace DSLink.Util.Logger
         /// </summary>
         /// <returns>The log level</returns>
         /// <param name="name">Name</param>
-        public LogLevel ParseLogLevel(string name)
+        public static LogLevel ParseLogLevel(string name)
         {
             return LogLevels[name.ToUpper()];
         }


### PR DESCRIPTION
Necessary for use of --log parameter on DSLink startup.