### PR TITLE
This is a minor bug fix for a race condition with _pingTask.

### DIFF
--- a/DSLink/DSLinkContainer.cs
+++ b/DSLink/DSLinkContainer.cs
@@ -72,7 +72,9 @@ namespace DSLink
             _isLinkInitialized = true;
 
             await _config._initKeyPair();
-            _pingTask = Task.Factory.StartNew(OnPingTaskElapsed);
+
+            _pingTask = new Task(OnPingTaskElapsed);
+            _pingTask.Start();
 
             if (Config.Responder)
             {


### PR DESCRIPTION
There is a chance that the thread pool will pick up the scheduled task and execute it before the _pingTask reference is set. If that happens, line 287 will throw an exception because _pingTask isn't defined yet.  This change removes that chance by initializing _pingTask first, then starting it.  Here's an MSDN article explaining exactly this situation and the recommended fix:
[https://blogs.msdn.microsoft.com/pfxteam/2010/06/13/task-factory-startnew-vs-new-task-start/](https://blogs.msdn.microsoft.com/pfxteam/2010/06/13/task-factory-startnew-vs-new-task-start/)

To test these changes, I first ran all of the unit tests in the project - they all passed successfully.  I then ran the example DSLinks locally against my local DSA broker and validated that everything worked.